### PR TITLE
Update extension to manifest version 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: npm ci
-    - run: npx web-ext lint
+    - run: npx web-ext lint --max-warnings 0
     - run: SELENIUM_BROWSER=${{ matrix.browser }} npm test
     - uses: ouzi-dev/commit-status-updater@v1.1.0
       with:

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ npm install
 Build using Mozilla's [`web-ext`](https://extensionworkshop.com/documentation/develop/getting-started-with-web-ext/) tool:
 
 ```
-web-ext lint
-web-ext build
+npx web-ext lint
+npx web-ext build
 ```
 
 Output will be under `web-ext-artifacts` and should be compatible with Firefox or

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "keyn",
     "developer": {
         "name": "James Elford",
@@ -8,10 +8,7 @@
     "version": "0.7.0",
     "description": "Navigate the world wide web with the power of your keyboard",
     "background": {
-        "scripts": [
-            "./lib/browser-polyfill.js",
-            "./js/keyn.js"
-        ]
+        "service_worker": "./js/keyn.js"
     },
     "commands": {
         "pick-clickable": {

--- a/web-ext-config.js
+++ b/web-ext-config.js
@@ -5,5 +5,6 @@ module.exports = {
     ignoreFiles: [
         "docs",
         "README.md"
-    ]
+    ],
+    manifestVersion: 3
 }


### PR DESCRIPTION
Update extension to use manifest version 3 and update build process.

* **manifest.json**
  - Update `manifest_version` to 3.
  - Replace `background` script configuration with `background.service_worker` configuration.

* **README.md**
  - Update build instructions to use `npx` with `web-ext` commands.

* **.github/workflows/build.yml**
  - Update `web-ext lint` command to use the latest version and set `--max-warnings` to 0.

* **web-ext-config.js**
  - Add `manifestVersion: 3` to the configuration.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jelford/keyn/pull/23?shareId=4320606e-e633-4477-9c4a-6d38e466c7e5).